### PR TITLE
adaptations for Linux

### DIFF
--- a/src/lwc-benchmarking/README.md
+++ b/src/lwc-benchmarking/README.md
@@ -10,6 +10,13 @@ The benchmarking framework was developed and tested on Windows 10. It does not u
 
 You need to make sure that the `PATH` environment variable is set for running `python` and `platformio` commands work from the current path. On Windows 10, the PlatformIO binaries are located at `/c/Users/[username]/.platformio/penv/Scripts/`.
 
+If your system has python installed as `python3`, you can define the environment variable `PYTHON`. Similarly, you can define `PLATFORMIO`. The defaults are `python` and `platformio.exe`.
+
+Typical setting for Linux:
+````
+export PYTHON=python3;export PLATFORMIO=platformio
+````
+
 ## Experiments and Operating Modes
 
 The framework is designed to process implementations and experiments one at a time. The implementation that is to be benchmarked must be copied under the `src\iut` folder. There must be exactly one implementation in this folder, otherwise the build will fail.
@@ -32,7 +39,7 @@ The build script that is explained in the next section creates a new `lwc_mode.h
 
 ## Building with the script `build.sh`
 
-The bash script `build.sh` processes the implementations by building them within the framework and depending on the experiment being done it uploads the program to the target device and captures the program output. At a minimum, the script must be provided a target platform name, which can be one of the platforms defined in the `platformio.ini` file. Currently, the valid platform names are `{mkrzero, uno, nano33ble, nano_every}`. 
+The bash script `build.sh` processes the implementations by building them within the framework and depending on the experiment being done it uploads the program to the target device and captures the program output. At a minimum, the script must be provided a target platform name, which can be one of the platforms defined in the `platformio.ini` file. Currently, the valid platform names are `{mkrzero, uno, nano33ble, nano_every}`.
 
 By default, the script processes all implementations and does all the experiments. However, the behaviour can be changed by providing command line arguments, for instance to process only one or more *submissions*, or *variants*, as well as performing select experiments. Running the script with no arguments gives an explanation of the set of available command line arguments. Some examples:
 
@@ -58,9 +65,8 @@ By default, the script processes all implementations and does all the experiment
 ```
 
 
-**Note:** For code size experiments, the device is not required since the code sizes are extracted from the build output. However, for *KAT* and *Timing* experiments, the program must run on the device and the output needs to be captured. 
+**Note:** For code size experiments, the device is not required since the code sizes are extracted from the build output. However, for *KAT* and *Timing* experiments, the program must run on the device and the output needs to be captured.
 
 ### Results
 
 The build script will save the results in the `outputs` folder. The results for each target platform are stored under their respective folders.
-


### PR DESCRIPTION
This pull request fixes 2 incompatibilities:
- Typically on Linux `python` is python2.7 and `python3` is python3.x. That's a 1st source of incompatibility.
- Using `platfromio.exe` is the 2nd source of incompatibility since the `.exe` extension is meaningful only on Windows.

The `build.sh` takes into account 2 environment variables:
- PYTHON: default is `python` as in the original version
- PLATFORMIO: default is `platformio.exe` as in the original version

The default values ensure that the behavior is unchanged on Windows (as long as those environment variables are not defined).

The readme gives the typical values needed on Linux.
